### PR TITLE
Ignore build directory while linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   lint:
+    concurrency:
+      group: lint-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.luarc.json
+++ b/.luarc.json
@@ -20,5 +20,6 @@
 	],
 	"runtime.version": "LuaJIT",
 	"type.castNumberToInteger": true,
-	"type.weakUnionCheck": true
+	"type.weakUnionCheck": true,
+	"workspace.ignoreDir": ["build"]
 }


### PR DESCRIPTION
As shown in the CI error from https://github.com/kevinhwang91/promise-async/actions/runs/4063199514/jobs/6995153223#step:4:14 :

```
Diagnosis complete, 154 problems found, see build/lua-language-server/check.json
{
    "file:///home/runner/lua-language-server/meta/LuaJIT%20en-us%20utf8/basic.lua": [
```

The linting job on CI can fail because it's linting files inside of the `build` directory. This PR fixes the problem by adding the `build` directory to `"workspace.ignoreDir"` (see https://github.com/LuaLS/vscode-lua/blob/4b25f3d9c3643ea27e4b6c8bb85b2f6f258972e3/setting/schema.json#L3096 and https://github.com/LuaLS/lua-language-server/issues/28#issuecomment-490365346).

---

While I was at it, I thought it'd be useful to add the [`concurrency` setting](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run) such that redundant jobs are canceled when you push a new commit to the branches for that workflow. The code for this was added in the second commit. Please let me know if you want me to remove that.