### PR TITLE
fix: do not lose stacktrace on errors when rejecting a promise

### DIFF
--- a/lua/async.lua
+++ b/lua/async.lua
@@ -59,7 +59,7 @@ function Async.sync(executor)
         local function afterResume(status, ...)
             if not status then
                 local reason = select(1, ...)
-                reject(reason)
+                reject(debug.traceback(co, reason))
                 return
             elseif coroutine.status(co) == 'dead' then
                 local value

--- a/lua/promise-async/error.lua
+++ b/lua/promise-async/error.lua
@@ -41,15 +41,14 @@ end
 ---@param thread? thread
 ---@param level number
 ---@param skipShortSrc? string
----@return boolean, string|nil
+---@return string?
 function Error.format(thread, level, skipShortSrc)
-    local ok = false
     local res
     local dInfo = thread and debug.getinfo(thread, level, 'nSl') or debug.getinfo(level, 'nSl')
     if dInfo then
         local name, shortSrc, currentline = dInfo.name, dInfo.short_src, dInfo.currentline
         if skipShortSrc == shortSrc then
-            return true, nil
+            return
         end
         local detail
         if not name or name == '' then
@@ -57,10 +56,9 @@ function Error.format(thread, level, skipShortSrc)
         else
             detail = ([[in function '%s']]):format(name)
         end
-        ok = true
         res = ('        %s:%d: %s'):format(shortSrc, currentline, detail)
     end
-    return ok, res
+    return res
 end
 
 ---@param err any


### PR DESCRIPTION
Problem: When a error happens while executing an asynchornous promise,
stacktrace information is lost. This makes debugging very difficult.
e.g.,

```
Error executing vim.schedule lua callback: UnhandledPromiseRejection with the reason:
...foo.lua: an error message
```

Solution: `pcall` will result in losing stacktrace. Use `xpcall` to
retain stacktrace information and use that for building error messages.
e.g.,

```
Error executing vim.schedule lua callback: UnhandledPromiseRejection with the reason:
...foo.lua:42: an error message
stack traceback:
    ...foo.lua:100: in function ...
    ...foo.lua:200: in function ...
    [C]: in function ...
```